### PR TITLE
fix: remove the duplicate key in ls-lint

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -8,7 +8,6 @@ ls:
     .data.ts: camelCase | kebab-case
     .test-d.ts: kebab-case
     .spec.ts: camelCase | PascalCase
-    .mock.ts: camelCase
 
 ignore:
   - node_modules


### PR DESCRIPTION
## Description
remove the duplicate key in ls-lint
## Fix or Feature?
Fix
### Environment

- OS: Write here
- NPM Version: Write here
