### PR TITLE
fix(style): add table title min-height

### DIFF
--- a/src/components/Table/src/BasicTable.vue
+++ b/src/components/Table/src/BasicTable.vue
@@ -331,6 +331,7 @@
       border-radius: 2px;
 
       .ant-table-title {
+        min-height: 40px;
         padding: 0 0 8px 0 !important;
       }
 


### PR DESCRIPTION
没有按钮的时候，高度只有32px，和有按钮的时候高度不一致