### PR TITLE
fix(modal): proptype conflict with ant design modal(fixed: #545)

### DIFF
--- a/src/components/Modal/src/BasicModal.vue
+++ b/src/components/Modal/src/BasicModal.vue
@@ -122,12 +122,14 @@
         wrapClassName: toRef(getMergeProps.value, 'wrapClassName'),
       });
 
-      // modal component does not need title
+      // modal component does not need title and origin buttons
       const getProps = computed(
         (): ModalProps => {
           const opt = {
             ...unref(getMergeProps),
             visible: unref(visibleRef),
+            okButtonProps: undefined,
+            cancelButtonProps: undefined,
             title: undefined,
           };
           return {


### PR DESCRIPTION
修复BasicModal组件的okButtonProps、cancelButtonProps属性与Ant design Modal组件的定义差别所引起的warn。