### PR TITLE
feat(qrcode): custom drawing support

### DIFF
--- a/src/components/Qrcode/src/types.ts
+++ b/src/components/Qrcode/src/types.ts
@@ -31,3 +31,8 @@ export type ToCanvasFn = (options: RenderQrCodeParams) => Promise<unknown>;
 export interface QrCodeActionType {
   download: (fileName?: string) => void;
 }
+
+export interface QrcodeDoneEventParams {
+  url: string;
+  ctx?: CanvasRenderingContext2D | null;
+}

--- a/src/views/demo/comp/qrcode/index.vue
+++ b/src/views/demo/comp/qrcode/index.vue
@@ -58,6 +58,19 @@
       <CollapseContainer title="配置大小示例" class="text-center qrcode-demo-item">
         <QrCode :value="qrCodeUrl" :width="300" />
       </CollapseContainer>
+
+      <CollapseContainer title="扩展绘制示例" class="text-center qrcode-demo-item">
+        <QrCode
+          :value="qrCodeUrl"
+          :width="200"
+          :options="{ margin: 5 }"
+          ref="qrDiyRef"
+          :logo="LogoImg"
+          @done="onQrcodeDone"
+        />
+        <a-button class="mb-2" type="primary" @click="downloadDiy"> 下载 </a-button>
+        <div class="msg"> 要进行扩展绘制则不能将tag设为img </div>
+      </CollapseContainer>
     </div>
   </PageWrapper>
 </template>
@@ -73,16 +86,36 @@
     components: { CollapseContainer, QrCode, PageWrapper },
     setup() {
       const qrRef = ref<Nullable<QrCodeActionType>>(null);
+      const qrDiyRef = ref<Nullable<QrCodeActionType>>(null);
       function download() {
         const qrEl = unref(qrRef);
         if (!qrEl) return;
         qrEl.download('文件名');
       }
+      function downloadDiy() {
+        const qrEl = unref(qrDiyRef);
+        if (!qrEl) return;
+        qrEl.download('Qrcode');
+      }
+
+      function onQrcodeDone({ ctx }) {
+        if (ctx instanceof CanvasRenderingContext2D) {
+          // 额外绘制
+          ctx.fillStyle = 'black';
+          ctx.font = '16px "微软雅黑"';
+          ctx.textBaseline = 'bottom';
+          ctx.textAlign = 'center';
+          ctx.fillText('你帅你先扫', 100, 195, 200);
+        }
+      }
       return {
+        onQrcodeDone,
         qrCodeUrl,
         LogoImg,
         download,
+        downloadDiy,
         qrRef,
+        qrDiyRef,
       };
     },
   });


### PR DESCRIPTION
修改QRcode组件的done事件的参数，传入画板的绘制上下文对象以便可以方便地对QRcode组件的二维码进行二次加工，比如绘制提示文字等等。在组件的示例页面增加了新的自定义绘制的例子。