### PR TITLE
fix: encryptByBase64 function (fixed: #587)

### DIFF
--- a/src/utils/cipher.ts
+++ b/src/utils/cipher.ts
@@ -43,7 +43,7 @@ export class AesEncryption {
 }
 
 export function encryptByBase64(cipherText: string) {
-  return Base64.parse(cipherText).toString(UTF8);
+  return UTF8.parse(cipherText).toString(Base64);
 }
 
 export function decodeByBase64(cipherText: string) {


### PR DESCRIPTION
修复Base64编码函数的错误