### PR TITLE
perf(tree): 改进beforeRightClick回调支持对菜单进行更多配置

### DIFF
--- a/src/components/Tree/src/index.vue
+++ b/src/components/Tree/src/index.vue
@@ -23,11 +23,12 @@
   import { filter } from '/@/utils/helper/treeHelper';
 
   import { useTree } from './useTree';
-  import { useContextMenu, ContextMenuItem } from '/@/hooks/web/useContextMenu';
+  import { useContextMenu } from '/@/hooks/web/useContextMenu';
   import { useExpose } from '/@/hooks/core/useExpose';
   import { useDesign } from '/@/hooks/web/useDesign';
 
   import { basicProps } from './props';
+  import { CreateContextOptions } from '/@/components/ContextMenu';
 
   interface State {
     expandedKeys: Keys;
@@ -128,18 +129,20 @@
 
       async function handleRightClick({ event, node }: Recordable) {
         const { rightMenuList: menuList = [], beforeRightClick } = props;
-        let rightMenuList: ContextMenuItem[] = [];
+        let contextMenuOptions: CreateContextOptions = { event, items: [] };
 
         if (beforeRightClick && isFunction(beforeRightClick)) {
-          rightMenuList = await beforeRightClick(node);
+          let result = await beforeRightClick(node, event);
+          if (Array.isArray(result)) {
+            contextMenuOptions.items = result;
+          } else {
+            Object.assign(contextMenuOptions, result);
+          }
         } else {
-          rightMenuList = menuList;
+          contextMenuOptions.items = menuList;
         }
-        if (!rightMenuList.length) return;
-        createContextMenu({
-          event,
-          items: rightMenuList,
-        });
+        if (!contextMenuOptions.items?.length) return;
+        createContextMenu(contextMenuOptions);
       }
 
       function setExpandedKeys(keys: Keys) {

--- a/src/components/Tree/src/props.ts
+++ b/src/components/Tree/src/props.ts
@@ -1,5 +1,5 @@
 import type { PropType } from 'vue';
-import type { ReplaceFields, ActionItem, Keys, CheckKeys } from './types';
+import type { ReplaceFields, ActionItem, Keys, CheckKeys, ContextMenuOptions } from './types';
 import type { ContextMenuItem } from '/@/hooks/web/useContextMenu';
 import type { TreeDataItem } from 'ant-design-vue/es/tree/Tree';
 import { propTypes } from '/@/utils/propTypes';
@@ -53,7 +53,7 @@ export const basicProps = {
   },
 
   beforeRightClick: {
-    type: Function as PropType<(...arg: any) => ContextMenuItem[]>,
+    type: Function as PropType<(...arg: any) => ContextMenuItem[] | ContextMenuOptions>,
     default: null,
   },
 

--- a/src/components/Tree/src/types.ts
+++ b/src/components/Tree/src/types.ts
@@ -1,4 +1,5 @@
 import type { TreeDataItem } from 'ant-design-vue/es/tree/Tree';
+import { ContextMenuItem } from '/@/hooks/web/useContextMenu';
 export interface ActionItem {
   render: (record: Recordable) => any;
   show?: boolean | ((record: Recordable) => boolean);
@@ -39,4 +40,10 @@ export interface InsertNodeParams {
   node: TreeDataItem;
   list?: TreeDataItem[];
   push?: 'push' | 'unshift';
+}
+
+export interface ContextMenuOptions {
+  icon?: string;
+  styles?: any;
+  items?: ContextMenuItem[];
 }


### PR DESCRIPTION
当tree处于抽屉或者对话框中时，右键菜单会因为z-index太低而没能显示在对话框或抽屉的上层。
此PR修改了对beforeRightClick的回调的处理，允许beforeRightClick返回菜单的items数组（兼容之前的代码写法）或者返回ContextMenuOptions来对右键菜单进行更多定制，比如返回{styles:{"z-index":2010},items}来让右键菜单可以在抽屉或弹窗中正确显示。