### PR TITLE
fix(tree): value prop type

### DIFF
--- a/src/components/Tree/src/props.ts
+++ b/src/components/Tree/src/props.ts
@@ -6,7 +6,7 @@ import { propTypes } from '/@/utils/propTypes';
 
 export const basicProps = {
   value: {
-    type: Array as PropType<Keys>,
+    type: [Object, Array] as PropType<Keys | CheckKeys>,
   },
   renderIcon: {
     type: Function as PropType<(params: Recordable) => string>,


### PR DESCRIPTION
当Tree启用checkable、checkStrictly属性时，checkedKeys的值是一个Object而不是Array。