### PR TITLE
fix(theme):  wrong color when RadioButtonGroup checked

### DIFF
--- a/build/vite/plugin/theme.ts
+++ b/build/vite/plugin/theme.ts
@@ -27,10 +27,13 @@ export function configThemePlugin(isBuild: boolean): Plugin[] {
         switch (s) {
           case '.ant-steps-item-process .ant-steps-item-icon > .ant-steps-icon':
             return '.ant-steps-item-icon > .ant-steps-icon';
+          case '.ant-radio-button-wrapper-checked:not(.ant-radio-button-wrapper-disabled)':
+          case '.ant-radio-button-wrapper-checked:not(.ant-radio-button-wrapper-disabled):hover':
+          case '.ant-radio-button-wrapper-checked:not(.ant-radio-button-wrapper-disabled):active':
+            return s;
           case '.ant-steps-item-icon > .ant-steps-icon':
             return s;
         }
-
         return `[data-theme] ${s}`;
       },
       colorVariables: [...getThemeColors(), ...colors],
@@ -58,5 +61,5 @@ export function configThemePlugin(isBuild: boolean): Plugin[] {
     }),
   ];
 
-  return (plugin as unknown) as Plugin[];
+  return plugin as unknown as Plugin[];
 }


### PR DESCRIPTION
修复非默认颜色主题时，RadioButtonGroup的checked状态的按钮文字颜色被覆盖为与背景相同颜色的问题。
![image](https://user-images.githubusercontent.com/17241274/118923152-b38f0300-b96d-11eb-9c09-17dcbb959bf9.png)
