### PR TITLE
feat(table): allow disable column in settings

### DIFF
--- a/src/components/Table/src/components/settings/ColumnSetting.vue
+++ b/src/components/Table/src/components/settings/ColumnSetting.vue
@@ -43,7 +43,7 @@
             <template v-for="item in plainOptions" :key="item.value">
               <div :class="`${prefixCls}__check-item`">
                 <DragOutlined class="table-coulmn-drag-icon" />
-                <Checkbox :value="item.value">
+                <Checkbox :value="item.value" :disabled="item.disabled">
                   {{ item.label }}
                 </Checkbox>
 
@@ -57,7 +57,7 @@
                       `${prefixCls}__fixed-left`,
                       {
                         active: item.fixed === 'left',
-                        disabled: !checkedList.includes(item.value),
+                        disabled: item.disabled || !checkedList.includes(item.value),
                       },
                     ]"
                     @click="handleColumnFixed(item, 'left')"
@@ -74,7 +74,7 @@
                       `${prefixCls}__fixed-right`,
                       {
                         active: item.fixed === 'right',
-                        disabled: !checkedList.includes(item.value),
+                        disabled: item.disabled || !checkedList.includes(item.value),
                       },
                     ]"
                     @click="handleColumnFixed(item, 'right')"
@@ -127,6 +127,7 @@
     label: string;
     value: string;
     fixed?: boolean | 'left' | 'right';
+    disabled?: boolean;
   }
 
   export default defineComponent({
@@ -192,6 +193,7 @@
           ret.push({
             label: (item.title as string) || (item.customTitle as string),
             value: (item.dataIndex || item.title) as string,
+            disabled: item.disabledInSettings,
             ...item,
           });
         });
@@ -319,7 +321,8 @@
       }
 
       function handleColumnFixed(item: BasicColumn, fixed?: 'left' | 'right') {
-        if (!state.checkedList.includes(item.dataIndex as string)) return;
+        if (item.disabledInSettings || !state.checkedList.includes(item.dataIndex as string))
+          return;
 
         const columns = getColumns() as BasicColumn[];
         const isFixed = item.fixed === fixed ? false : fixed;

--- a/src/components/Table/src/types/table.ts
+++ b/src/components/Table/src/types/table.ts
@@ -426,4 +426,6 @@ export interface BasicColumn extends ColumnProps {
   auth?: RoleEnum | RoleEnum[] | string | string[];
   // 业务控制是否显示
   ifShow?: boolean | ((column: BasicColumn) => boolean);
+  // 是否在表格列设置中禁用
+  disabledInSettings?: boolean;
 }

--- a/src/views/demo/table/tableData.tsx
+++ b/src/views/demo/table/tableData.tsx
@@ -13,6 +13,7 @@ export function getBasicColumns(): BasicColumn[] {
       title: '姓名',
       dataIndex: 'name',
       width: 150,
+      disabledInSettings: true,
       filters: [
         { text: 'Male', value: 'male' },
         { text: 'Female', value: 'female' },


### PR DESCRIPTION
为BasicColumns新增disabledInSettings属性，可控制列是否在表格的列设置模块中禁用（不允许改变列的fixed属性且不允许改变列的可见状态）。
