### PR TITLE
fix: session timeout login logic error

### DIFF
--- a/src/store/modules/permission.ts
+++ b/src/store/modules/permission.ts
@@ -65,6 +65,7 @@ export const usePermissionStore = defineStore({
 
     setBackMenuList(list: Menu[]) {
       this.backMenuList = list;
+      list?.length > 0 && this.setLastBuildMenuTime();
     },
 
     setLastBuildMenuTime() {

--- a/src/views/sys/login/SessionTimeoutLogin.vue
+++ b/src/views/sys/login/SessionTimeoutLogin.vue
@@ -6,15 +6,44 @@
   </transition>
 </template>
 <script lang="ts">
-  import { defineComponent } from 'vue';
+  import { defineComponent, onBeforeUnmount, onMounted, ref } from 'vue';
   import Login from './Login.vue';
 
   import { useDesign } from '/@/hooks/web/useDesign';
+  import { useUserStore } from '/@/store/modules/user';
+  import { usePermissionStore } from '/@/store/modules/permission';
+  import { useAppStore } from '/@/store/modules/app';
+  import { PermissionModeEnum } from '/@/enums/appEnum';
   export default defineComponent({
     name: 'SessionTimeoutLogin',
     components: { Login },
     setup() {
       const { prefixCls } = useDesign('st-login');
+      const userStore = useUserStore();
+      const permissionStore = usePermissionStore();
+      const appStore = useAppStore();
+      const userId = ref<Nullable<number | string>>(0);
+
+      const isBackMode = () => {
+        return appStore.getProjectConfig.permissionMode === PermissionModeEnum.BACK;
+      };
+
+      onMounted(() => {
+        // 记录当前的UserId
+        userId.value = userStore.getUserInfo?.userId;
+        console.log('Mounted', userStore.getUserInfo);
+      });
+
+      onBeforeUnmount(() => {
+        if (userId.value && userId.value !== userStore.getUserInfo.userId) {
+          // 登录的不是同一个用户，刷新整个页面以便丢弃之前用户的页面状态
+          document.location.reload();
+        } else if (isBackMode() && permissionStore.getLastBuildMenuTime === 0) {
+          // 后台权限模式下，没有成功加载过菜单，就重新加载整个页面。这通常发生在会话过期后按F5刷新整个页面后载入了本模块这种场景
+          document.location.reload();
+        }
+      });
+
       return { prefixCls };
     },
   });


### PR DESCRIPTION
修复超时重新登录的页面在某些逻辑下未能正确刷新数据的问题。

1、后台权限模式下，如果在token失效或过期之后直接手动F5刷新页面，会在请求菜单数据时收到接口应答要求重新登陆，此时如果载入了session timeout login组件的话，登录成功后没能重新请求菜单数据。

2、无论何种权限模式下，session timeout login组件在登陆成功后，假如登录的并非之前的用户，应当刷新页面丢弃就用户的页面状态
