### PR TITLE
fix: Fix the problem that the `lang` attribute of `HTML` will not be set when it is first loaded

### DIFF
--- a/src/locales/setupI18n.ts
+++ b/src/locales/setupI18n.ts
@@ -3,7 +3,7 @@ import type { I18n, I18nOptions } from 'vue-i18n';
 
 import { createI18n } from 'vue-i18n';
 
-import { setLoadLocalePool } from './useLocale';
+import { setLoadLocalePool, setHtmlPageLang } from './useLocale';
 import { localeSetting } from '/@/settings/localeSetting';
 import { useLocaleStoreWithOut } from '/@/store/modules/locale';
 
@@ -16,7 +16,8 @@ async function createI18nOptions(): Promise<I18nOptions> {
   const locale = localeStore.getLocale;
   const defaultLocal = await import(`./lang/${locale}.ts`);
   const message = defaultLocal.default?.message ?? {};
-
+  
+  setHtmlPageLang(locale)
   setLoadLocalePool((loadLocalePool) => {
     loadLocalePool.push(locale);
   });

--- a/src/locales/useLocale.ts
+++ b/src/locales/useLocale.ts
@@ -17,6 +17,10 @@ interface LangModule {
 
 const loadLocalePool: LocaleType[] = [];
 
+export function setHtmlPageLang(locale: LocaleType) {
+  document.querySelector('html')?.setAttribute('lang', locale);
+}
+
 export function setLoadLocalePool(cb: (loadLocalePool: LocaleType[]) => void) {
   cb(loadLocalePool);
 }
@@ -30,7 +34,7 @@ function setI18nLanguage(locale: LocaleType) {
     (i18n.global.locale as any).value = locale;
   }
   localeStore.setLocaleInfo({ locale });
-  document.querySelector('html')?.setAttribute('lang', locale);
+  setHtmlPageLang(locale)
 }
 
 export function useLocale() {


### PR DESCRIPTION
修复首次加载或改变语言导致重载时，不会设置 `HTML` 的 `lang` 属性