### PR TITLE
fix(Tinymce):  Read only status upload button can also be used

### DIFF
--- a/src/components/Tinymce/src/Editor.vue
+++ b/src/components/Tinymce/src/Editor.vue
@@ -6,6 +6,7 @@
       @done="handleDone"
       v-if="showImageUpload"
       v-show="editorRef"
+      :disabled="disabled"
     />
     <textarea :id="tinymceId" ref="elRef" :style="{ visibility: 'hidden' }"></textarea>
   </div>
@@ -170,6 +171,12 @@
         };
       });
 
+      const disabled = computed(() => {
+        const { options } = props;
+        const getdDisabled = options && Reflect.get(options, 'readonly');
+        return getdDisabled ?? false;
+      });
+
       watch(
         () => attrs.disabled,
         () => {
@@ -301,6 +308,7 @@
         handleDone,
         editorRef,
         fullscreen,
+        disabled,
       };
     },
   });

--- a/src/components/Tinymce/src/ImgUpload.vue
+++ b/src/components/Tinymce/src/ImgUpload.vue
@@ -8,14 +8,14 @@
       :showUploadList="false"
       accept=".jpg,.jpeg,.gif,.png,.webp"
     >
-      <a-button type="primary">
+      <a-button type="primary" v-bind="{ ...getButtonProps }">
         {{ t('component.upload.imgUpload') }}
       </a-button>
     </Upload>
   </div>
 </template>
 <script lang="ts">
-  import { defineComponent } from 'vue';
+  import { defineComponent, computed } from 'vue';
 
   import { Upload } from 'ant-design-vue';
   import { useDesign } from '/@/hooks/web/useDesign';
@@ -29,14 +29,25 @@
       fullscreen: {
         type: Boolean,
       },
+      disabled: {
+        type: Boolean,
+        default: false,
+      },
     },
     emits: ['uploading', 'done', 'error'],
-    setup(_, { emit }) {
+    setup(props, { emit }) {
       let uploading = false;
 
       const { uploadUrl } = useGlobSetting();
       const { t } = useI18n();
       const { prefixCls } = useDesign('tinymce-img-upload');
+
+      const getButtonProps = computed(() => {
+        const { disabled } = props;
+        return {
+          disabled,
+        };
+      });
 
       function handleChange(info: Recordable) {
         const file = info.file;
@@ -63,6 +74,7 @@
         handleChange,
         uploadUrl,
         t,
+        getButtonProps,
       };
     },
   });


### PR DESCRIPTION
*修复富文本组件在只读状态下上传图片按钮也能点击的bug
