### PR TITLE
fix: fix endOfLine error report in Windows IDE

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,5 +72,6 @@ module.exports = defineConfig({
         math: 'always',
       },
     ],
+    'linebreak-style': 'off',
   },
 });

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -15,6 +15,6 @@ module.exports = {
   requirePragma: false,
   proseWrap: 'never',
   htmlWhitespaceSensitivity: 'strict',
-  endOfLine: 'lf',
+  endOfLine: 'auto',
   rangeStart: 0,
 };


### PR DESCRIPTION
    * 修复Windows环境中CRLF和LF的报错
