### PR TITLE
fix: 修复在页脚开启时候 getViewHeight 超出范围的问题。

### DIFF
--- a/src/layouts/default/content/index.vue
+++ b/src/layouts/default/content/index.vue
@@ -11,7 +11,6 @@
   import { useDesign } from '/@/hooks/web/useDesign';
   import { useRootSetting } from '/@/hooks/setting/useRootSetting';
   import { useTransitionSetting } from '/@/hooks/setting/useTransitionSetting';
-  import { useContentViewHeight } from './useContentViewHeight';
 
   export default defineComponent({
     name: 'LayoutContent',
@@ -21,7 +20,6 @@
       const { getOpenPageLoading } = useTransitionSetting();
       const { getLayoutContentMode, getPageLoading } = useRootSetting();
 
-      useContentViewHeight();
       return {
         prefixCls,
         getOpenPageLoading,

--- a/src/layouts/default/content/useContentViewHeight.ts
+++ b/src/layouts/default/content/useContentViewHeight.ts
@@ -2,12 +2,13 @@ import { ref, computed, unref } from 'vue';
 import { createPageContext } from '/@/hooks/component/usePageContext';
 import { useWindowSizeFn } from '/@/hooks/event/useWindowSizeFn';
 export const headerHeightRef = ref(0);
+export const footerHeightRef = ref(0);
 
 export function useContentViewHeight() {
   const contentHeight = ref(window.innerHeight);
   const pageHeight = ref(window.innerHeight);
   const getViewHeight = computed(() => {
-    return unref(contentHeight) - unref(headerHeightRef) || 0;
+    return unref(contentHeight) - unref(headerHeightRef) - unref(footerHeightRef) || 0;
   });
 
   useWindowSizeFn(

--- a/src/layouts/default/footer/index.vue
+++ b/src/layouts/default/footer/index.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts">
-  import { computed, defineComponent, unref } from 'vue';
+  import { computed, defineComponent, unref, ref } from 'vue';
   import { Layout } from 'ant-design-vue';
 
   import { GithubFilled } from '@ant-design/icons-vue';
@@ -24,6 +24,7 @@
   import { useRootSetting } from '/@/hooks/setting/useRootSetting';
   import { useRouter } from 'vue-router';
   import { useDesign } from '/@/hooks/web/useDesign';
+  import { footerHeightRef, useContentViewHeight } from '../content/useContentViewHeight';
 
   export default defineComponent({
     name: 'LayoutFooter',
@@ -33,11 +34,29 @@
       const { getShowFooter } = useRootSetting();
       const { currentRoute } = useRouter();
       const { prefixCls } = useDesign('layout-footer');
+      const footerRef = ref<ComponentRef>(null);
 
       const getShowLayoutFooter = computed(() => {
+        if (unref(getShowFooter)) {
+          const footerEl = unref(footerRef)?.$el;
+          footerHeightRef.value = footerEl?.offsetHeight || 0;
+        } else {
+          footerHeightRef.value = 0;
+        }
         return unref(getShowFooter) && !unref(currentRoute).meta?.hiddenFooter;
       });
-      return { getShowLayoutFooter, prefixCls, t, DOC_URL, GITHUB_URL, SITE_URL, openWindow };
+
+      useContentViewHeight();
+      return {
+        getShowLayoutFooter,
+        prefixCls,
+        t,
+        DOC_URL,
+        GITHUB_URL,
+        SITE_URL,
+        openWindow,
+        footerRef,
+      };
     },
   });
 </script>


### PR DESCRIPTION
### `General`

修复在页脚开启时候 `getViewHeight` 超出范围的问题。

此bug会导致`PageWrapper`在开启`contentFullHeight`时，看不到页脚（需要滑动）

快速修复，暂未考虑将 `useContentViewHeight.ts` 在 `footer` 内调用将带来的问题，应该也没啥问题。

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
