### PR TITLE
perf(PageWrapper): 优化PageWrapper在page的footer与全局页脚同时开启时的高度计算表现。

### DIFF
--- a/CHANGELOG.zh_CN.md
+++ b/CHANGELOG.zh_CN.md
@@ -18,6 +18,7 @@
 - **PageWrapper** 修复高度计算问题
 - **FlowChart** 修复拖放菜单丢失
 - 修复后台模式下，Iframe 路由错误
+- **PageWrapper** 修复 footer 与全局页脚同时开启时的高度计算问题
 
 ## 2.4.2(2021-06-10)
 

--- a/src/components/Page/src/PageWrapper.vue
+++ b/src/components/Page/src/PageWrapper.vue
@@ -96,7 +96,6 @@
           ...contentStyle,
           minHeight: height,
           ...(fixedHeight ? { height } : {}),
-          paddingBottom: `${unref(footerHeight)}px`,
         };
       });
 
@@ -166,7 +165,36 @@
           const contentMarginTop = Number(marginTop.replace(/[^\d]/g, ''));
           subtractHeight += contentMarginTop;
         }
-        setPageHeight?.(unref(contentHeight) - unref(footerHeight) - headerHeight - subtractHeight);
+
+        // fix: wrapper marginTop and marginBottom value
+        let wrapperSubtractHeight = 0;
+        let wrapperMarginBottom = ZERO_PX;
+        let wrapperMarginTop = ZERO_PX;
+        const wrapperClassElments = document.querySelectorAll(`.${prefixVar}-page-wrapper`);
+        if (wrapperClassElments && wrapperClassElments.length > 0) {
+          const contentEl = wrapperClassElments[0];
+          const cssStyle = getComputedStyle(contentEl);
+          wrapperMarginBottom = cssStyle?.marginBottom ?? ZERO_PX;
+          wrapperMarginTop = cssStyle?.marginTop ?? ZERO_PX;
+        }
+        if (wrapperMarginBottom) {
+          const contentMarginBottom = Number(wrapperMarginBottom.replace(/[^\d]/g, ''));
+          wrapperSubtractHeight += contentMarginBottom;
+        }
+        if (wrapperMarginTop) {
+          const contentMarginTop = Number(wrapperMarginTop.replace(/[^\d]/g, ''));
+          wrapperSubtractHeight += contentMarginTop;
+        }
+        let height =
+          unref(contentHeight) -
+          unref(footerHeight) -
+          headerHeight -
+          subtractHeight -
+          wrapperSubtractHeight;
+        if (unref(getShowFooter)) {
+          height -= unref(footerHeightRef);
+        }
+        setPageHeight?.(height);
       }
 
       return {

--- a/src/layouts/default/footer/index.vue
+++ b/src/layouts/default/footer/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <Footer :class="prefixCls" v-if="getShowLayoutFooter">
+  <Footer :class="prefixCls" v-if="getShowLayoutFooter" ref="footerRef">
     <div :class="`${prefixCls}__links`">
       <a @click="openWindow(SITE_URL)">{{ t('layout.footer.onlinePreview') }}</a>
 


### PR DESCRIPTION
perf(PageWrapper): 优化PageWrapper在page的footer与全局页脚同时开启时的高度计算表现。

## 问题

contentHeight 未计算 全局footer 高度，开启PageWrapper的footer时会全局遮挡

## 解决

1. 高度计算时，如果全局footer开启，需要减去全局footer
2. 取消padding-bottom

> 当前尚未解决被PageWrapper的footer直接遮挡 全局footer 的问题。  PageWrapper的footer是浮动状态。