### PR TITLE
fix(pagewrapper): 修复pagewrapper自适应高度计算错误，修复useContentViewHeight未减去foo…

### DIFF
--- a/src/components/Page/src/PageWrapper.vue
+++ b/src/components/Page/src/PageWrapper.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="getClass">
+  <div :class="getClass" ref="wrapperRef">
     <PageHeader
       :ghost="ghost"
       :title="title"
@@ -18,7 +18,7 @@
       </template>
     </PageHeader>
 
-    <div class="overflow-hidden" :class="getContentClass" :style="getContentStyle">
+    <div class="overflow-hidden" :class="getContentClass" :style="getContentStyle" ref="contentRef">
       <slot></slot>
     </div>
 
@@ -64,9 +64,10 @@
       fixedHeight: propTypes.bool,
     },
     setup(props, { slots }) {
+      const wrapperRef = ref<ElRef>(null);
       const headerRef = ref<ComponentRef>(null);
+      const contentRef = ref<ElRef>(null);
       const footerRef = ref<ComponentRef>(null);
-      const footerHeight = ref(0);
       const { prefixCls, prefixVar } = useDesign('page-wrapper');
       const { contentHeight, setPageHeight, pageHeight } = usePageContext();
       const { footerHeightRef } = useLayoutHeight();
@@ -131,70 +132,76 @@
         if (!props.contentFullHeight) {
           return;
         }
-        //fix:in contentHeight mode: delay getting footer and header dom element to get the correct height
-        const footer = unref(footerRef);
-        const header = unref(headerRef);
-        footerHeight.value = 0;
-        const footerEl = footer?.$el;
+        const subtractMargin = (element: HTMLElement | null | undefined): number => {
+          let subtractHeight = 0;
+          const ZERO_PX = '0px';
+          let marginBottom = ZERO_PX;
+          let marginTop = ZERO_PX;
+          if (element) {
+            const cssStyle = getComputedStyle(element);
+            marginBottom = cssStyle?.marginBottom ?? ZERO_PX;
+            marginTop = cssStyle?.marginTop ?? ZERO_PX;
+          }
+          if (marginBottom) {
+            const contentMarginBottom = Number(marginBottom.replace(/[^\d]/g, ''));
+            subtractHeight += contentMarginBottom;
+          }
+          if (marginTop) {
+            const contentMarginTop = Number(marginTop.replace(/[^\d]/g, ''));
+            subtractHeight += contentMarginTop;
+          }
+          return subtractHeight;
+        };
 
-        if (footerEl) {
-          footerHeight.value += footerEl?.offsetHeight ?? 0;
-        }
+        const collectElementsUntilCSS = (
+          element: HTMLElement | undefined | null,
+          clsName: string
+        ): HTMLElement[] => {
+          const result: HTMLElement[] = [];
+          const findElement = (element: HTMLElement | undefined | null, clsName: string) => {
+            if (element && !element.classList.contains(clsName)) {
+              result.push(element);
+              findElement(element?.parentElement, clsName);
+            }
+          };
+          findElement(element, clsName);
+          return result;
+        };
+
+        //fix:in contentHeight mode: delay getting footer and header dom element to get the correct height
+        const wrapperEl = unref(wrapperRef);
+        const header = unref(headerRef);
+        const contentEl = unref(contentRef);
+        const footer = unref(footerRef);
+
         let headerHeight = 0;
         const headerEl = header?.$el;
         if (headerEl) {
           headerHeight += headerEl?.offsetHeight ?? 0;
         }
-        // fix:subtract content's marginTop and marginBottom value
-        let subtractHeight = 0;
-        const ZERO_PX = '0px';
-        let marginBottom = ZERO_PX;
-        let marginTop = ZERO_PX;
-        const classElments = document.querySelectorAll(`.${prefixVar}-page-wrapper-content`);
-        if (classElments && classElments.length > 0) {
-          const contentEl = classElments[0];
-          const cssStyle = getComputedStyle(contentEl);
-          marginBottom = cssStyle?.marginBottom ?? ZERO_PX;
-          marginTop = cssStyle?.marginTop ?? ZERO_PX;
-        }
-        if (marginBottom) {
-          const contentMarginBottom = Number(marginBottom.replace(/[^\d]/g, ''));
-          subtractHeight += contentMarginBottom;
-        }
-        if (marginTop) {
-          const contentMarginTop = Number(marginTop.replace(/[^\d]/g, ''));
-          subtractHeight += contentMarginTop;
+
+        let footerHeight = 0;
+        const footerEl = footer?.$el;
+        if (footerEl) {
+          footerHeight += footerEl?.offsetHeight ?? 0;
         }
 
-        // fix: wrapper marginTop and marginBottom value
+        // fix: subtract wrappers's marginTop and marginBotton value
         let wrapperSubtractHeight = 0;
-        let wrapperMarginBottom = ZERO_PX;
-        let wrapperMarginTop = ZERO_PX;
-        const wrapperClassElments = document.querySelectorAll(`.${prefixVar}-page-wrapper`);
-        if (wrapperClassElments && wrapperClassElments.length > 0) {
-          const contentEl = wrapperClassElments[0];
-          const cssStyle = getComputedStyle(contentEl);
-          wrapperMarginBottom = cssStyle?.marginBottom ?? ZERO_PX;
-          wrapperMarginTop = cssStyle?.marginTop ?? ZERO_PX;
-        }
-        if (wrapperMarginBottom) {
-          const contentMarginBottom = Number(wrapperMarginBottom.replace(/[^\d]/g, ''));
-          wrapperSubtractHeight += contentMarginBottom;
-        }
-        if (wrapperMarginTop) {
-          const contentMarginTop = Number(wrapperMarginTop.replace(/[^\d]/g, ''));
-          wrapperSubtractHeight += contentMarginTop;
-        }
-        let height =
+        collectElementsUntilCSS(wrapperEl, `${prefixVar}-layout-content`)?.forEach((it) => {
+          wrapperSubtractHeight += subtractMargin(it);
+        });
+
+        // fix:subtract content's marginTop and marginBottom value
+        const subtractHeight = subtractMargin(contentEl);
+
+        setPageHeight?.(
           unref(contentHeight) -
-          unref(footerHeight) -
-          headerHeight -
-          subtractHeight -
-          wrapperSubtractHeight;
-        if (unref(getShowFooter)) {
-          height -= unref(footerHeightRef);
-        }
-        setPageHeight?.(height);
+            headerHeight -
+            footerHeight -
+            subtractHeight -
+            wrapperSubtractHeight
+        );
       }
 
       return {

--- a/src/layouts/default/content/useContentViewHeight.ts
+++ b/src/layouts/default/content/useContentViewHeight.ts
@@ -19,7 +19,7 @@ export function useContentViewHeight() {
   const contentHeight = ref(window.innerHeight);
   const pageHeight = ref(window.innerHeight);
   const getViewHeight = computed(() => {
-    return unref(contentHeight) - unref(headerHeightRef) || 0;
+    return unref(contentHeight) - unref(headerHeightRef) - unref(footerHeightRef) || 0;
   });
 
   useWindowSizeFn(


### PR DESCRIPTION
> 修复pagewrapper自适应高度计算错误，修复useContentViewHeight未减去footerHeightRef的问题。

## 修复

1. PageWrapper父组件不是 `vben-layout-content` 的情况
2. 修复useContentViewHeight 高度计算忘记减去 `unref(footerHeightRef) ` 的问题

## 对于 `1` 的说明

针对PageWrapper外部还套用HTMLElement的情况，解决方法比较粗暴，即：收集其所有父节点dom，计算所有marginTop与marginBottom总和。

```vue
<!-- 如下这种不是直接使用PageWrapper的情况（特殊：一般来说，不应该这样用PageWrapper） -->
<template>
  <div :class="[prefixCls, 'mx-5', 'mt-5']">
      <PageWrapper
        contentFullHeight />
  </div>
</template>
```

```typescript
// 向上递归wrapper直到指定css名称被发现为止
// TODO: 该方法比较粗暴，可能需要大佬修修。
const collectElementsUntilCSS = (
          element: HTMLElement | undefined | null,
          clsName: string
        ): HTMLElement[] => {
          const result: HTMLElement[] = [];
          const findElement = (element: HTMLElement | undefined | null, clsName: string) => {
            if (element && !element.classList.contains(clsName)) {
              result.push(element);
              findElement(element?.parentElement, clsName);
            }
          };
          findElement(element, clsName);
          return result;
        };

// 累加
let wrapperSubtractHeight = 0;
        collectElementsUntilCSS(wrapperEl, `${prefixVar}-layout-content`)?.forEach((it) => {
          wrapperSubtractHeight += subtractMargin(it);
});
```

当前表现如下：

![](https://pan.noahlan.com/api/v3/file/get/8762/screen-202106176.gif?sign=GHOz-7S00GxOPnlrcApPgg7o5JrMexou-lwJTPnw9tA%3D%3A0)

动图有点颜色不正

![](https://pan.noahlan.com/api/v3/file/get/8763/2021-06-17_162719.png?sign=SX3N609Vx4CndaCgZpQkNt-epRbpISUWwk1sQwuhQAM%3D%3A0)