### PR TITLE
fix(comp-tree): support comp-tree-foreach stop,add insertNodesByKey

### DIFF
--- a/src/components/Tree/src/typing.ts
+++ b/src/components/Tree/src/typing.ts
@@ -31,6 +31,7 @@ export interface TreeActionType {
   getCheckedKeys: () => CheckKeys;
   filterByLevel: (level: number) => void;
   insertNodeByKey: (opt: InsertNodeParams) => void;
+  insertNodesByKey: (opt: InsertNodeParams) => void;
   deleteNodeByKey: (key: string) => void;
   updateNodeByKey: (key: string, node: Omit<TreeDataItem, 'key'>) => void;
 }

--- a/src/components/Tree/src/useTree.ts
+++ b/src/components/Tree/src/useTree.ts
@@ -87,11 +87,39 @@ export function useTree(
       if (treeItem[keyField] === parentKey) {
         treeItem[childrenField] = treeItem[childrenField] || [];
         treeItem[childrenField][push](node);
+        return true;
       }
     });
     treeDataRef.value = treeData;
   }
+  /**
+   * 批量添加节点
+   */
+  function insertNodesByKey({ parentKey = null, list, push = 'push' }: InsertNodeParams) {
+    const treeData: any = cloneDeep(unref(treeDataRef));
+    if (!list || list.length < 1) {
+      return;
+    }
+    if (!parentKey) {
+      for (let i = 0; i < list.length; i++) {
+        treeData[push](list[i]);
+      }
+    } else {
+      const { key: keyField, children: childrenField } = unref(getReplaceFields);
+      if (!childrenField || !keyField) return;
 
+      forEach(treeData, (treeItem) => {
+        if (treeItem[keyField] === parentKey) {
+          treeItem[childrenField] = treeItem[childrenField] || [];
+          for (let i = 0; i < list.length; i++) {
+            treeItem[childrenField][push](list[i]);
+          }
+          treeDataRef.value = treeData;
+          return true;
+        }
+      });
+    }
+  }
   // Delete node
   function deleteNodeByKey(key: string, list?: TreeDataItem[]) {
     if (!key) return;
@@ -111,5 +139,12 @@ export function useTree(
       }
     }
   }
-  return { deleteNodeByKey, insertNodeByKey, filterByLevel, updateNodeByKey, getAllKeys };
+  return {
+    deleteNodeByKey,
+    insertNodeByKey,
+    insertNodesByKey,
+    filterByLevel,
+    updateNodeByKey,
+    getAllKeys,
+  };
 }

--- a/src/utils/helper/treeHelper.ts
+++ b/src/utils/helper/treeHelper.ts
@@ -147,7 +147,10 @@ export function forEach<T = any>(
   const list: any[] = [...tree];
   const { children } = config;
   for (let i = 0; i < list.length; i++) {
-    func(list[i]);
+    //func 返回true就终止遍历，避免大量节点场景下无意义循环，引起浏览器卡顿
+    if (func(list[i])) {
+      return;
+    }
     children && list[i][children] && list.splice(i + 1, 0, ...list[i][children]);
   }
 }


### PR DESCRIPTION
Subject of the feature
优化tree组件遍历函数支持批量插入子节点

Problem
当树节点非常大的时候，插入节点的函数出现性能不佳浏览器卡顿
api仅提供了插入单个子节点，插入多个节点重复调用性能较差
Expected behaviour
在treeHelper forEach中根据节点处理返回true及时终止无意义遍历
提供批量插入 insertNodesByKey