### PR TITLE
fix: routes filter can't effective when permission mode set to ROUTE_…

### DIFF
--- a/src/store/modules/permission.ts
+++ b/src/store/modules/permission.ts
@@ -122,7 +122,7 @@ export const usePermissionStore = defineStore({
         case PermissionModeEnum.ROUTE_MAPPING:
           routes = filter(asyncRoutes, routeFilter);
           routes = routes.filter(routeFilter);
-          const menuList = transformRouteToMenu(asyncRoutes, true);
+          const menuList = transformRouteToMenu(routes, true);
           menuList.sort((a, b) => {
             return (a.meta?.orderNo || 0) - (b.meta?.orderNo || 0);
           });


### PR DESCRIPTION
…MAPPING

### `General`

> ✏️ 修复 PermissionMode为ROUTE_MAPPING时，路由过滤器未生效
