### PR TITLE
fix: typo

### DIFF
--- a/src/components/Cropper/src/CopperModal.vue
+++ b/src/components/Cropper/src/CopperModal.vue
@@ -130,7 +130,7 @@
   };
 
   export default defineComponent({
-    name: 'CropperAvatar',
+    name: 'CropperModal',
     components: { BasicModal, Space, CropperImage, Upload, Avatar, Tooltip },
     props,
     emits: ['uploadSuccess', 'register'],


### PR DESCRIPTION
我怎么说在 `vue-tools` 中找不到 `CropperModal` 组件