### PR TITLE
fix: typo for utils/env

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -46,7 +46,7 @@ export function getAppEnvConfig() {
 }
 
 /**
- * @description: Development model
+ * @description: Development mode
  */
 export const devMode = 'development';
 


### PR DESCRIPTION
修复环境变量下定义开发模式的描述信息