### PR TITLE
fix: 修复table自适应高度和title属性声明问题

### DIFF
--- a/src/components/Table/src/hooks/useTableFooter.ts
+++ b/src/components/Table/src/hooks/useTableFooter.ts
@@ -8,7 +8,7 @@ export function useTableFooter(
   propsRef: ComputedRef<BasicTableProps>,
   scrollRef: ComputedRef<{
     x: string | number | true;
-    y: Nullable<number>;
+    y: string | number | null;
     scrollToFirstRowOnChange: boolean;
   }>,
   tableElRef: Ref<ComponentRef>,

--- a/src/components/Table/src/hooks/useTableScroll.ts
+++ b/src/components/Table/src/hooks/useTableScroll.ts
@@ -1,6 +1,6 @@
 import type { BasicTableProps, TableRowSelection, BasicColumn } from '../types/table';
 import type { Ref, ComputedRef } from 'vue';
-import { computed, unref, ref, nextTick, watch } from 'vue';
+import { computed, unref, nextTick, watch } from 'vue';
 import { getViewportOffset } from '/@/utils/domUtils';
 import { isBoolean } from '/@/utils/is';
 import { useWindowSizeFn } from '/@/hooks/event/useWindowSizeFn';
@@ -15,8 +15,6 @@ export function useTableScroll(
   rowSelectionRef: ComputedRef<TableRowSelection | null>,
   getDataSourceRef: ComputedRef<Recordable[]>,
 ) {
-  const tableHeightRef: Ref<Nullable<number>> = ref(null);
-
   const modalFn = useModalContext();
 
   // Greater than animation time 280
@@ -43,8 +41,7 @@ export function useTableScroll(
     });
   }
 
-  function setHeight(height: number) {
-    tableHeightRef.value = height;
+  function setHeight() {
     //  Solve the problem of modal adaptive height calculation when the form is placed in the modal
     modalFn?.redoModalHeight?.();
   }
@@ -141,7 +138,7 @@ export function useTableScroll(
       headerHeight;
 
     height = (height > maxHeight! ? (maxHeight as number) : height) ?? height;
-    setHeight(height);
+    setHeight();
 
     bodyEl!.style.height = `${height}px`;
   }
@@ -179,11 +176,10 @@ export function useTableScroll(
   });
 
   const getScrollRef = computed(() => {
-    const tableHeight = unref(tableHeightRef);
     const { canResize, scroll } = unref(propsRef);
     return {
       x: unref(getScrollX),
-      y: canResize ? tableHeight : null,
+      y: canResize ? '100%' : null,
       scrollToFirstRowOnChange: false,
       ...scroll,
     };

--- a/src/components/Table/src/types/table.ts
+++ b/src/components/Table/src/types/table.ts
@@ -1,10 +1,8 @@
 import type { VNodeChild } from 'vue';
 import type { PaginationProps } from './pagination';
 import type { FormProps } from '/@/components/Form';
-import type {
-  ColumnProps,
-  TableRowSelection as ITableRowSelection,
-} from 'ant-design-vue/lib/table/interface';
+import type { TableRowSelection as ITableRowSelection } from 'ant-design-vue/lib/table/interface';
+import type { ColumnProps } from 'ant-design-vue/lib/table';
 
 import { ComponentType } from './componentType';
 import { VueNode } from '/@/utils/propTypes';


### PR DESCRIPTION
1.修复table升级ant3.0导致无法自适应剩余高度
2.修复table升级ant3.0导致BasicColumn类型的title属性无法找到