### PR TITLE
fix(table component): reduce 'insertTableDataRecord' code logic

### DIFF
--- a/src/components/Table/src/hooks/useDataSource.ts
+++ b/src/components/Table/src/hooks/useDataSource.ts
@@ -196,11 +196,10 @@ export function useDataSource(
   }
 
   function insertTableDataRecord(record: Recordable, index: number): Recordable | undefined {
-    if (!dataSourceRef.value || dataSourceRef.value.length == 0) return;
+    // if (!dataSourceRef.value || dataSourceRef.value.length == 0) return;
     index = index ?? dataSourceRef.value?.length;
     unref(dataSourceRef).splice(index, 0, record);
-    unref(propsRef).dataSource?.splice(index, 0, record);
-    return unref(propsRef).dataSource;
+    return unref(dataSourceRef);
   }
 
   function findTableDataRecord(rowKey: string | number) {


### PR DESCRIPTION
### `场景描述 `

- 因为 `unref(dataSourceRef).splice(index, 0, record);  unref(propsRef).dataSource?.splice(index, 0, record);`同时存在时会导致添加俩条数据的情况发生；并且在 `useDataSource.ts` 中 line:60 `!api && dataSource && (dataSourceRef.value = dataSource);` 已经把 props 中的 `dataSource` 赋值给了 `dataSourceRef` 所以这里只保留 `unref(dataSourceRef).splice(index, 0, record);` 即可
- 注释掉 `if (!dataSourceRef.value || dataSourceRef.value.length == 0) return;` 的原因是因为 `dataSourceRef` 在初始化时已经给了默认值见 line:49 ；并且开发在使用时的场景是不论表格有没有数据使用了该方法那就是希望向表格中添加数据，所以注释掉了。
- 上述俩点我均在我们的项目中测试了接口返回异步数据与传入静态数据俩种情况已经通过测试。

### `General`

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

